### PR TITLE
Add minimum tested pixel count to rotate the document

### DIFF
--- a/CmdLineOptions.pas
+++ b/CmdLineOptions.pas
@@ -25,6 +25,7 @@ uses
 const
   DefaultThreshold = 128;
   DefaultMaxAngle = 10;
+  DefaultMinTestedPixels = 25;
   DefaultSkipAngle = 0.01;
 
 type
@@ -54,6 +55,7 @@ type
     FInputFileName: string;
     FOutputFileName: string;
     FMaxAngle: Double;
+    FMinTestedPixels: Integer;
     FSkipAngle: Double;
     FResamplingFilter: TResamplingFilter;
     FThresholdingMethod: TThresholdingMethod;
@@ -86,6 +88,8 @@ type
     property OutputFileName: string read FOutputFileName;
     // Max expected rotation angle - algo then works in range [-MaxAngle, MaxAngle]
     property MaxAngle: Double read FMaxAngle;
+    // Minimum tested pixels for any rotation
+    property MinTestedPixels: Integer read FMinTestedPixels;
     // Skew threshold angle - skip deskewing if detected skew angle is in range (-MinAngle, MinAngle)
     property SkipAngle: Double read FSkipAngle;
     // Resampling filter used for rotations
@@ -155,6 +159,7 @@ constructor TCmdLineOptions.Create;
 begin
   FThresholdLevel := DefaultThreshold;
   FMaxAngle := DefaultMaxAngle;
+  FMinTestedPixels := DefaultMinTestedPixels;
   FSkipAngle := DefaultSkipAngle;
   FResamplingFilter := rfLinear;
   FThresholdingMethod := tmOtsu;
@@ -174,6 +179,7 @@ end;
 function TCmdLineOptions.GetIsValid: Boolean;
 begin
   Result := (InputFileName <> '') and (MaxAngle > 0) and (SkipAngle >= 0) and
+    (MinTestedPixels > 0) and
     ((ThresholdingMethod in [tmOtsu]) or (ThresholdingMethod = tmExplicit) and (ThresholdLevel > 0));
 end;
 
@@ -291,6 +297,11 @@ var
     begin
       if not TryStrToFloat(Value, FMaxAngle, FFormatSettings) then
         FErrorMessage := 'Invalid value for max angle parameter: ' + Value;
+    end
+    else if Param = '-m' then
+    begin
+      if not TryStrToInt(Value, FMinTestedPixels) then
+        FErrorMessage := 'Invalid value for minimum tested pixels parameter: ' + Value;
     end
     else if Param = '-l' then
     begin
@@ -556,6 +567,7 @@ begin
     '  input file          = ' + InputFileName + sLineBreak +
     '  output file         = ' + OutputFileName + sLineBreak +
     '  max angle           = ' + FloatToStr(MaxAngle) + sLineBreak +
+    '  min tested pixels   = ' + FloatToStr(MinTestedPixels) + sLineBreak +
     '  background color    = ' + IntToHex(BackgroundColor, 8) + sLineBreak +
     '  resampling filter   = ' + FilterStr + sLineBreak +
     '  thresholding method = ' + Iff(ThresholdingMethod = tmExplicit, 'explicit', 'auto otsu') + sLineBreak +

--- a/MainUnit.pas
+++ b/MainUnit.pas
@@ -65,6 +65,7 @@ begin
   WriteLn('  Options:');
   WriteLn('    -o output:     Output image file name (default: prefixed input as png)');
   WriteLn('    -a angle:      Maximal expected skew angle (both directions) in degrees (default: 10)');
+  WriteLn('    -m min_tested: Minimum number of tested pixels for any rotation (default: 25)');
   WriteLn('    -b color:      Background color in hex format RRGGBB|LL|AARRGGBB (default: black)');
   WriteLn('  Ext. options:');
   WriteLn('    -q filter:     Resampling filter used for rotations (default: linear');
@@ -199,8 +200,8 @@ begin
   // Main step - calculate image rotation SkewAngle
   WriteLn('Calculating skew angle...');
   Time := GetTimeMicroseconds;
-  SkewAngle := CalcRotationAngle(Options.MaxAngle, Threshold,
-    InputImage.Width, InputImage.Height, InputImage.Bits,
+  SkewAngle := CalcRotationAngle(Options.MaxAngle, Options.MinTestedPixels,
+    Threshold, InputImage.Width, InputImage.Height, InputImage.Bits,
     @ContentRect, @Stats);
   WriteTiming('Skew detection');
   WriteLn('Skew angle found [deg]: ', SkewAngle:4:3);

--- a/RotationDetector.pas
+++ b/RotationDetector.pas
@@ -37,14 +37,15 @@ type
   work only in defined part of image (useful when the document has text only in
   smaller area of page and non-text features outside the area confuse the rotation detector).
   Various calculations stats can be retrieved by passing Stats parameter.}
-function CalcRotationAngle(const MaxAngle: Double; Treshold: Integer;
-  Width, Height: Integer; Pixels: PByteArray; DetectionArea: PRect = nil;
+function CalcRotationAngle(const MaxAngle: Double; const MinTestedPixels: Integer;
+  Treshold: Integer; Width, Height: Integer; Pixels: PByteArray; DetectionArea: PRect = nil;
   Stats: PCalcSkewAngleStats = nil): Double;
 
 implementation
 
-function CalcRotationAngle(const MaxAngle: Double; Treshold: Integer;
-  Width, Height: Integer; Pixels: PByteArray; DetectionArea: PRect; Stats: PCalcSkewAngleStats): Double;
+function CalcRotationAngle(const MaxAngle: Double; const MinTestedPixels: Integer;
+  Treshold: Integer; Width, Height: Integer; Pixels: PByteArray; DetectionArea:
+  PRect; Stats: PCalcSkewAngleStats): Double;
 const
   // Number of "best" lines we take into account when determining
   // resulting rotation angle (lines with most votes).
@@ -193,8 +194,12 @@ begin
 
   // Average angles of the selected lines to get the rotation angle of the image
   SumAngles := 0;
-  for I := 0 to BestLinesCount - 1 do
-    SumAngles := SumAngles + BestLines[I].Alpha;
+  // We want to make sure there are enough pixels to be meaningful
+  if (AccumulatedCounts div AlphaSteps) >= MinTestedPixels then
+  begin
+    for I := 0 to BestLinesCount - 1 do
+      SumAngles := SumAngles + BestLines[I].Alpha;
+  end;
 
   Result := SumAngles / BestLinesCount;
 


### PR DESCRIPTION
This is particularly useful for blank pages where deskew might detect a few pixels and try to rotate based on that, causing blank pages to rotate at weird angles..